### PR TITLE
fix: training in 1 host machine

### DIFF
--- a/serve.sh
+++ b/serve.sh
@@ -1,13 +1,16 @@
 export NCCL_P2P_DISABLE=1
 export VLLM_ALLOW_INSECURE_SERIALIZATION=1
 export CUDA_VISIBLE_DEVICES=0,1
+export HF_HUB_ENABLE_HF_TRANSFER=1
 export VLLM_USE_V1=1
 export NCCL_DEBUG=INFO
-# export VLLM_TRACE_FUNCTION=1
- # --batch-request-timeout-seconds 36000 \
-CUDA_VISIBLE_DEVICES=0,1 python verifiers/inference/vllm_server.py \
+export NCCL_SHM_DISABLE=0
+export NCCL_CUMEM_HOST_ENABLE=0
+export NCCL_CUMEM_ENABLE=0
+export NCCL_IGNORE_DISABLED_P2P=1
+python verifiers/inference/vllm_server.py \
     --model 'jan-hq/Qwen3-4B-v0.3-deepresearch-100-step' \
-    --tensor-parallel-size 2 \
+    --tensor-parallel-size 4 \
     --data-parallel-size 1 \
     --max-model-len 40960 \
     --dtype bfloat16 \

--- a/train.sh
+++ b/train.sh
@@ -1,7 +1,10 @@
-# export NCCL_P2P_DISABLE=0
-export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
-CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 accelerate launch --config-file configs/zero3.yaml --num_processes 8 verifiers/examples/trl_stage_3.py \
-    --async_generation_timeout 3600 --vllm_server_host 10.200.108.158 --num_generations 8 --model_name Menlo/Jan-nano \
+export NCCL_P2P_DISABLE=1
+export HF_HUB_ENABLE_HF_TRANSFER=1
+export NCCL_SHM_DISABLE=0
+export NCCL_DEBUG=INFO
+export NCCL_IGNORE_DISABLED_P2P=1
+export CUDA_VISIBLE_DEVICES=4,5,6,7
+CUDA_VISIBLE_DEVICES=4,5,6,7 accelerate launch --config-file configs/zero3.yaml --num_processes 4 verifiers/examples/trl_stage_3.py \
+    --async_generation_timeout 3600 --vllm_server_host 0.0.0.0 --num_generations 4 --model_name Menlo/Jan-nano \
     --max_completion_length 40960 --hub_model_id jan-hq/Jan-nano-v0.1 --wandb_project jan-nano-v0.1-cherry-prompt --max_steps_env 30 \
     --run_name jan-nano-128k
-    


### PR DESCRIPTION
Fix https://github.com/menloresearch/deep-research/issues/4
we need to export several environment variables to serve and training script before training to fix nccl bugs when train in 1 host machine
test successfully in:
- 1 runpod container
- 8xA6000 VM
