### PR TITLE
fix: Fix empty preview text when 1st sentence >200 chars

### DIFF
--- a/verifiers/tools/search_visit_rag.py
+++ b/verifiers/tools/search_visit_rag.py
@@ -144,20 +144,20 @@ def _create_preview(text: str, max_sentences: int = 2, max_chars: int = 200) -> 
     """Create a preview from text content."""
     if not text:
         return "No preview available"
-    
+
     # Split into sentences
     sentences = re.split(r'[.!?]+', text)
     sentences = [s.strip() for s in sentences if s.strip()]
-    
-    preview = ""
-    for i, sentence in enumerate(sentences[:max_sentences]):
+
+    preview = sentences[0]
+    for sentence in sentences[1:max_sentences]:
         if len(preview + sentence) > max_chars:
             break
         preview += sentence + ". "
-    
+
     if len(preview) > max_chars:
         preview = preview[:max_chars].rsplit(' ', 1)[0] + "..."
-    
+
     return preview.strip()
 
 


### PR DESCRIPTION
## Problem

https://github.com/menloresearch/verifiers-deepresearch/blob/92d503c1b13da4b61a86554458ee9da5224622dd/verifiers/tools/search_visit_rag.py#L149-L153

This logic means that if the 1st sentence is too long (>200 chars), preview text will be empty.

E.g.

```python
from verifiers.tools.search_visit_rag import _create_preview

text = "According to several Malaysian trade and economic officials, KL is set to recognise US halal certification on several products, including pharmaceuticals, as “their certification is quite good” and the Malaysian Islamic Development Department, the local certifying body, has vetted the process."
_create_preview(text)
```

3b6ab1ea - empty
This PR - `According to several Malaysian trade and economic officials, KL is set to recognise US halal certification on several products, including pharmaceuticals, as “their certification is quite good” and...`
