### PR TITLE
fix: include `role="user"` for `visit_tool_reward_func()`

### DIFF
--- a/verifiers/rubrics/tool_rubric.py
+++ b/verifiers/rubrics/tool_rubric.py
@@ -372,7 +372,8 @@ class ToolRubric(Rubric):
                 parsed = self.parser.parse(msg['content'])
                 if hasattr(parsed, 'tool_call') and parsed.tool_call is not None:
                     # Found a properly formatted tool message
-                    if i + 1 < len(completion) and completion[i + 1]['role'] == 'tool':
+                    # OldToolEnv uses role="user", ToolEnv uses role="tool"
+                    if i + 1 < len(completion) and completion[i + 1]['role'] in ('tool', 'user'):
                         tool_attempts += 1
                         # Check response with env_parser
                         parsed_response = self.env_parser.parse(


### PR DESCRIPTION
`OldToolEnv` uses `role="user"`

https://github.com/menloresearch/verifiers-deepresearch/blob/4916149bf7eac73f01afed0c0a9910bc1cd0eab5/verifiers/envs/old_tool_env.py#L209-L213

New `ToolEnv` uses `role="tool"`

https://github.com/menloresearch/verifiers-deepresearch/blob/4916149bf7eac73f01afed0c0a9910bc1cd0eab5/verifiers/envs/tool_env.py#L39-L43

Hence, we need to check for both

Sanity check with a training run

<img width="420" height="312" alt="image" src="https://github.com/user-attachments/assets/40221843-cabc-407d-bcf5-beb42e0117a8" />
