### PR TITLE
fix: change `args` to `arguments` to follow Qwen3 tool template

### DIFF
--- a/verifiers/envs/old_tool_env.py
+++ b/verifiers/envs/old_tool_env.py
@@ -140,20 +140,21 @@ class ToolEnv(MultiTurnEnv):
         try:
             command = json.loads(tool_json)
             if not isinstance(command, dict):
-                return 'Error: Parse tool '+tool_json + ' failed. Tool command must be a JSON object, e.g. \'{"name": "tool_name", "args": {"arg1": "value1", "arg2": "value2"}}\''
+                return 'Error: Parse tool '+tool_json + ' failed. Tool command must be a JSON object, e.g. \'{"name": "tool_name", "arguments": {"arg1": "value1", "arg2": "value2"}}\''
 
             tool_name = command.get("name")
             if not tool_name:
-                return 'Error: Tool command must specify \'name\', e.g. \'{"name": "tool_name", "args": {"arg1": "value1", "arg2": "value2"}}\''
+                return 'Error: Tool command must specify \'name\', e.g. \'{"name": "tool_name", "arguments": {"arg1": "value1", "arg2": "value2"}}\''
 
             if tool_name not in self.tools:
                 return (
                     f"Error: Unknown tool '{tool_name}. "
-                    + 'Please format your tool call as \'{"name": "tool_name", "args": {"arg1": "value1", "arg2": "value2"}}\''
+                    + 'Please format your tool call as \'{"name": "tool_name", "arguments": {"arg1": "value1", "arg2": "value2"}}\''
                 )
 
+            # follow Qwen3 template
             tool_func = self.tools[tool_name]
-            tool_args = command.get("args", {})
+            tool_args = command.get("arguments", {})
             if isinstance(tool_args, str):
                 tool_schema = next(
                     (
@@ -173,7 +174,7 @@ class ToolEnv(MultiTurnEnv):
         except Exception as e:
             return (
                 f"Error: call tool {tool_json} with error: '{str(e)}'. "
-                + 'Please format your tool call as \'{"name": "tool_name", "args": {{"arg1": "value1", "arg2": "value2"}}\''
+                + 'Please format your tool call as \'{"name": "tool_name", "arguments": {{"arg1": "value1", "arg2": "value2"}}\''
             )
 
     def env_response(

--- a/verifiers/examples/trl_stage_3.py
+++ b/verifiers/examples/trl_stage_3.py
@@ -42,12 +42,12 @@ When handling user queries:
 
 1. When you need to search for information, call the "web_search" tool using this exact XML format:
 <tool_call>
-{{"name": "web_search", "args": {{"query": "your search query here"}}}}
+{{"name": "web_search", "arguments": {{"query": "your search query here"}}}}
 </tool_call>
 
 2. If search results show promising URLs/documents but you need more detailed information, use the "visit_tool" tool:
 <tool_call>
-{{"name": "visit_tool", "args": {{"url": "doc_1 or specific URL from search results"}}}}
+{{"name": "visit_tool", "arguments": {{"url": "doc_1 or specific URL from search results"}}}}
 </tool_call>
 
 3. Tool results will appear inside <result>...</result> tags
@@ -67,7 +67,7 @@ I'll search for this information first, then visit specific pages if needed.
 
 
 <tool_call>
-{{"name": "web_search", "args": {{"query": "McDonald's founding date founder history"}}}}
+{{"name": "web_search", "arguments": {{"query": "McDonald's founding date founder history"}}}}
 </tool_call>
 
 <result>
@@ -83,7 +83,7 @@ Preview: Ray Kroc joined McDonald's in 1955 and transformed it into a global fra
 </result>
 
 <tool_call>
-{{"name": "visit_tool", "args": {{"url": "doc_1"}}}}
+{{"name": "visit_tool", "arguments": {{"url": "doc_1"}}}}
 </tool_call>
 
 <result>

--- a/verifiers/examples/trl_stage_3_think.py
+++ b/verifiers/examples/trl_stage_3_think.py
@@ -47,12 +47,12 @@ When handling user queries:
 
 2. When you need to search for information, call the "web_search" tool using this exact XML format:
 <tool_call>
-{{"name": "web_search", "args": {{"query": "your search query here"}}}}
+{{"name": "web_search", "arguments": {{"query": "your search query here"}}}}
 </tool_call>
 
 3. If search results show promising URLs/documents but you need more detailed information, use the "visit_tool" tool:
 <tool_call>
-{{"name": "visit_tool", "args": {{"url": "doc_1 or specific URL from search results"}}}}
+{{"name": "visit_tool", "arguments": {{"url": "doc_1 or specific URL from search results"}}}}
 </tool_call>
 
 4. Tool response results will appear inside <tool_response>...</tool_response> tags
@@ -70,7 +70,7 @@ I'll search for this information first, then visit specific pages if needed.
 </think>
 
 <tool_call>
-{{"name": "web_search", "args": {{"query": "McDonald's founding date founder history"}}}}
+{{"name": "web_search", "arguments": {{"query": "McDonald's founding date founder history"}}}}
 </tool_call>
 
 <tool_response>
@@ -86,7 +86,7 @@ Preview: Ray Kroc joined McDonald's in 1955 and transformed it into a global fra
 </tool_response>
 
 <tool_call>
-{{"name": "visit_tool", "args": {{"url": "doc_1"}}}}
+{{"name": "visit_tool", "arguments": {{"url": "doc_1"}}}}
 </tool_call>
 
 <tool_response>


### PR DESCRIPTION
- In `old_tool_env.py`, change `args` to `arguments`
- In our training scripts, change the examples from `args` to `arguments`